### PR TITLE
daq: Strip DAQ device names

### DIFF
--- a/daqpower/daq.py
+++ b/daqpower/daq.py
@@ -81,7 +81,7 @@ def list_available_devices():
         bufsize = 2048  # Should be plenty for all but the most pathalogical of situations.
         buf = create_string_buffer('\000' * bufsize)
         DAQmxGetSysDevNames(buf, bufsize)
-        return buf.value.split(',')
+        return [name.strip() for name in buf.value.split(',')]
     else:
         return []
 


### PR DESCRIPTION
Sometime DAQ device names can be prefixed with additional spaces causing
name matching to fail. Now ensure that each name is stripped before
returning.