### PR TITLE
docs: Add readthedocs config and requirements.txt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: doc/source/conf.py
+
+# Build the docs in additional formats such as PDF and ePub
+formats: all
+
+# Set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+     - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==4.2
+sphinx-rtd-theme==1.0.0
+docutils<0.18


### PR DESCRIPTION
The default versions used for sphinx and docuilts on
readthedocs are no longer compatible. Explicitly list
the package versions that should be used when building
the documentation.